### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [
         .systemLibrary(name: "CPuppy"),


### PR DESCRIPTION
XCode sometimes gets confused and doesn't resolve the dependency correctly, if the `.git` is omitted from the dependency url. When it happens, XCode will complain about missing package `Logging`