### PR TITLE
Make `BaseLogger` inheritable outside of the module(`Puppy`).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Update `cmake-build` for Linux. [#19](https://github.com/sushichop/Puppy/pull/19)
 - Workaround for `carthage build` in both Xcode 12 and 13. [#20](https://github.com/sushichop/Puppy/pull/20)
-- Follow up `Integrate modules into Xcode`. [#21](https://github.com/sushichop/Puppy/pull/21)
+- Follow up `Integrate modules into Xcode`. [#22](https://github.com/sushichop/Puppy/pull/22)
+- Make `BaseLogger` inheritable outside of the module(`Puppy`). [#23](https://github.com/sushichop/Puppy/pull/23)
 
 ## [0.2.0](https://github.com/sushichop/Puppy/releases/tag/x.y.z) (2021-06-17)
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ class LogFormatter: LogFormattable {
 }
 ```
 
+### Create a custom logger
+
+You can create your own custom logger. All you have to do is inherit `BaseLogger` class and override `log(_:string:)` method.
+
+```swift
+import Puppy
+
+class CustomLogger: BaseLogger {
+    override func log(_ level: LogLevel, string: String) {
+        // Implements the logging feature here.
+    }
+}
+```
+
 
 ## License
 

--- a/Sources/Puppy/BaseLogger.swift
+++ b/Sources/Puppy/BaseLogger.swift
@@ -8,7 +8,7 @@ public protocol Loggerable {
     func log(_ level: LogLevel, string: String)
 }
 
-public class BaseLogger: Loggerable {
+open class BaseLogger: Loggerable {
 
     public var enabled: Bool = true
     public var logLevel: LogLevel = .trace
@@ -47,8 +47,8 @@ public class BaseLogger: Loggerable {
         self.queue = asynchronous ? DispatchQueue(label: label) : nil
     }
 
-    public func log(_ level: LogLevel, string: String) {
-
+    open func log(_ level: LogLevel, string: String) {
+        // Implements the logging feature here.
     }
 }
 


### PR DESCRIPTION
This PR refers to #21.