### PR TITLE
Add interface to construct a FileLogger from an existing FileHandle.

### DIFF
--- a/Sources/Puppy/FileError.swift
+++ b/Sources/Puppy/FileError.swift
@@ -6,4 +6,5 @@ public enum FileError: Error, Equatable {
     case creatingFileFailed(at: URL)
     case writingFailed(at: URL)
     case deletingFailed(at: URL)
+    case missingFileURL
 }

--- a/Sources/Puppy/FileLogger.swift
+++ b/Sources/Puppy/FileLogger.swift
@@ -7,20 +7,23 @@ public class FileLogger: BaseLogger {
     private var fileHandle: FileHandle!
     private let fileURL: URL?
     private let closeHandleOnDeinit: Bool
+    private let seekable: Bool
 
     public init(_ label: String, fileURL: URL) throws {
         self.fileURL = fileURL
         self.closeHandleOnDeinit = true
+        self.seekable = true
         debug("fileURL is \(fileURL).")
         super.init(label)
         try validateFileURL(fileURL)
         try openFile()
     }
 
-    public init(_ label: String, file: FileHandle, callerCloses: Bool = true) {
+    public init(_ label: String, file: FileHandle, callerCloses: Bool = true, seekable: Bool = true) {
         self.fileURL = nil
         self.closeHandleOnDeinit = !callerCloses
         self.fileHandle = file
+        self.seekable = seekable
         super.init(label)
     }
 
@@ -30,7 +33,9 @@ public class FileLogger: BaseLogger {
 
     public override func log(_ level: LogLevel, string: String) {
         do {
-            _ = try fileHandle?.seekToEndCompatible()
+            if seekable {
+                _ = try fileHandle?.seekToEndCompatible()
+            }
             if let data = (string + "\r\n").data(using: .utf8) {
                 // swiftlint:disable force_try
                 try! fileHandle?.writeCompatible(contentsOf: data)

--- a/Tests/PuppyTests/PuppyTests.swift
+++ b/Tests/PuppyTests/PuppyTests.swift
@@ -48,4 +48,11 @@ class PuppyTests: XCTestCase {
               "42".colorize(.colorNumber(42))
         )
     }
+
+    func testFileLoggerToStdout() throws {
+            let log: Puppy = Puppy.default
+            let fileLogger = FileLogger("label", file: FileHandle.standardOutput, callerCloses: true)
+            log.add(fileLogger)
+            log.info("This test output is directed to stdout.")
+    }
 }


### PR DESCRIPTION
If callerCloses is set, we assume that the caller will close the
handle when appropriate; otherwise we close the given handle on
deinit.

I am unsure why the existing code seeks to the end of the file before every write. I assume you have reasons, but if not, a simpler fix to the "seekable" issue would be to simply remove the seek in log().