### PR TITLE
Add suffix extension types for `FileRotationLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `FileRotatonLogger` inherits `FileLogger`. [#29](https://github.com/sushichop/Puppy/pull/29)
 - Add asynchronous methods for `delete` and `flush`. [#30](https://github.com/sushichop/Puppy/pull/30)
 - Add `test_spec` in `podspec`. [#31](https://github.com/sushichop/Puppy/pull/31)
+- Add suffix extension types for `FileRotationLogger`. [#32](https://github.com/sushichop/Puppy/pull/32)
 
 ## [0.3.1](https://github.com/sushichop/Puppy/releases/tag/0.3.1) (2021-08-18)
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         let fileRotation = try! FileRotationLogger("com.example.yourapp.filerotation",
-                                                   fileURL: "./rotation/foo.log")
+                                                   fileURL: "./logs/foo.log")
+        fileRotation.suffixExtension = .date_uuid   // Default option is `.numbering`.
         fileRotation.maxFileSize = 10 * 1024 * 1024
         fileRotation.maxArchivedFilesCount = 5
         fileRotation.delegate = delegate

--- a/Sources/Puppy/FileLogger.swift
+++ b/Sources/Puppy/FileLogger.swift
@@ -2,6 +2,10 @@ import Foundation
 
 public class FileLogger: BaseLogger {
 
+    public enum FlushMode {
+        case always
+        case manual
+    }
     public private(set) var flushMode: FlushMode
 
     var fileHandle: FileHandle!
@@ -32,7 +36,7 @@ public class FileLogger: BaseLogger {
                 }
             }
         } catch {
-            print("seekToEnd error. error is \(error.localizedDescription).")
+            print("error in seekToEnd, error: \(error.localizedDescription)")
         }
     }
 
@@ -101,7 +105,7 @@ public class FileLogger: BaseLogger {
         let directoryURL = fileURL.deletingLastPathComponent()
         do {
             try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
-            debug("created directoryURL is \(directoryURL).")
+            debug("created directoryURL, directoryURL: \(directoryURL)")
         } catch {
             throw FileError.creatingDirectoryFailed(at: directoryURL)
         }
@@ -109,12 +113,12 @@ public class FileLogger: BaseLogger {
         if !FileManager.default.fileExists(atPath: fileURL.path) {
             let successful = FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
             if successful {
-                debug("succeeded in creating filePath.")
+                debug("succeeded in creating filePath")
             } else {
                 throw FileError.creatingFileFailed(at: fileURL)
             }
         } else {
-            debug("filePath exists. filePath is \(fileURL.path).")
+            debug("filePath exists, filePath: \(fileURL.path)")
         }
 
         if fileHandle == nil {
@@ -139,11 +143,6 @@ public class FileLogger: BaseLogger {
             throw FileError.isNotFile(url: url)
         }
     }
-}
-
-public enum FlushMode {
-    case always
-    case manual
 }
 
 extension FileHandle {

--- a/Sources/Puppy/FileRotationLogger.swift
+++ b/Sources/Puppy/FileRotationLogger.swift
@@ -2,6 +2,14 @@ import Foundation
 
 public class FileRotationLogger: FileLogger {
 
+    public enum SuffixExtension {
+        case numbering
+        // swiftlint:disable identifier_name
+        case date_uuid
+        // swiftlint:enable identifier_name
+    }
+    public var suffixExtension: SuffixExtension = .date_uuid
+
     public typealias ByteCount = UInt64
     public var maxFileSize: ByteCount = 10 * 1024 * 1024
     public var maxArchivedFilesCount: UInt8 = 5
@@ -19,51 +27,89 @@ public class FileRotationLogger: FileLogger {
     }
 
     private func rotateFiles() {
-        if let size = try? fileHandle.seekToEndCompatible(), size > maxFileSize {
-            closeFile()
-            do {
-                let archivedFileURL = fileURL.deletingPathExtension()
-                    .appendingPathExtension(dateFormatter(Date(), dateFormat: "yyyyMMdd'T'HHmmss.SSSZZZZZ", timeZone: "GMT") + "_" + UUID().uuidString.lowercased())
-                try FileManager.default.moveItem(at: fileURL, to: archivedFileURL)
-                delegate?.fileRotationLogger(self, didArchiveFileURL: fileURL, toFileURL: archivedFileURL)
-            } catch {
-                print("moving error. error.localizedDescription is \(error.localizedDescription).")
-            }
+        guard let size = try? fileHandle.seekToEndCompatible(), size > maxFileSize else { return }
+        closeFile()
 
-            // Removes old archived file
-            let archivedDirectoryURL = fileURL.deletingLastPathComponent()
+        // Rotates old archived files.
+        switch suffixExtension {
+        case .numbering:
             do {
-                let archivedFileURLs = try FileManager.default
-                    .contentsOfDirectory(at: archivedDirectoryURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
-                    .filter { $0 != fileURL }
-
-                if archivedFileURLs.count > maxArchivedFilesCount {
-                    let sortedArchivedFileURLs = try archivedFileURLs.sorted {
-                        let creationDate0 = try FileManager.default.attributesOfItem(atPath: $0.path)[.modificationDate] as? Date
-                        let creationDate1 = try FileManager.default.attributesOfItem(atPath: $1.path)[.modificationDate] as? Date
-                        return creationDate0!.timeIntervalSince1970 < creationDate1!.timeIntervalSince1970
-                    }
-                    debug("sortedArchivedFileURLs is \(sortedArchivedFileURLs).")
-                    for index in 0 ..< archivedFileURLs.count - Int(maxArchivedFilesCount) {
-                        debug("\(sortedArchivedFileURLs[index]) will be removed...")
-                        try FileManager.default.removeItem(at: sortedArchivedFileURLs[index])
-                        debug("\(sortedArchivedFileURLs[index]) has been removed.")
-                        delegate?.fileRotationLogger(self, didRemoveArchivedFileURL: sortedArchivedFileURLs[index])
+                let oldArchivedFileURLs = ascArchivedFileURLs(fileURL)
+                for (index, oldArchivedFileURL) in oldArchivedFileURLs.enumerated() {
+                    let generationNumber = oldArchivedFileURLs.count + 1 - index
+                    let rotatedFileURL = oldArchivedFileURL.deletingPathExtension().appendingPathExtension("\(generationNumber)")
+                    debug("generationNumber: \(generationNumber), rotatedFileURL: \(rotatedFileURL)")
+                    if !FileManager.default.fileExists(atPath: rotatedFileURL.path) {
+                        try FileManager.default.moveItem(at: oldArchivedFileURL, to: rotatedFileURL)
                     }
                 }
             } catch {
-                print("archivedFileURLs error. error is \(error.localizedDescription).")
+                print("error in rotating old archive files, error: \(error.localizedDescription)")
             }
-
-            do {
-                debug("will openFile in rotateFiles.")
-                try openFile()
-            } catch {
-                print("openFile error in rotating. error is \(error.localizedDescription).")
-            }
-
+        case .date_uuid:
+            break
         }
 
+        // Archives the target file.
+        do {
+            var archivedFileURL: URL
+            switch suffixExtension {
+            case .numbering:
+                archivedFileURL = fileURL.appendingPathExtension("1")
+            case .date_uuid:
+                archivedFileURL = fileURL.appendingPathExtension(dateFormatter(Date(), dateFormat: "yyyyMMdd'T'HHmmssZZZZZ", timeZone: "UTC") + "_" + UUID().uuidString.lowercased())
+            }
+            try FileManager.default.moveItem(at: fileURL, to: archivedFileURL)
+            delegate?.fileRotationLogger(self, didArchiveFileURL: fileURL, toFileURL: archivedFileURL)
+        } catch {
+            print("error in archiving the target file, error: \(error.localizedDescription)")
+        }
+
+        // Removes extra archived files.
+        removeArchivedFiles(fileURL, maxArchivedFilesCount: maxArchivedFilesCount)
+
+        // Opens a new target file.
+        do {
+            debug("will openFile in rotateFiles")
+            try openFile()
+        } catch {
+            print("error in openFile while rotating, error: \(error.localizedDescription)")
+        }
+    }
+
+    private func ascArchivedFileURLs(_ fileURL: URL) -> [URL] {
+        var ascArchivedFileURLs: [URL] = []
+        do {
+            let archivedDirectoryURL = fileURL.deletingLastPathComponent()
+            let archivedFileURLs = try FileManager.default
+                .contentsOfDirectory(at: archivedDirectoryURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
+                .filter { $0 != fileURL && $0.deletingPathExtension() == fileURL }
+            ascArchivedFileURLs = try archivedFileURLs.sorted {
+                let modificationDate0 = try FileManager.default.attributesOfItem(atPath: $0.path)[.modificationDate] as? Date
+                let modificationDate1 = try FileManager.default.attributesOfItem(atPath: $1.path)[.modificationDate] as? Date
+                return modificationDate0!.timeIntervalSince1970 < modificationDate1!.timeIntervalSince1970
+            }
+        } catch {
+            print("error in ascArchivedFileURLs, error: \(error.localizedDescription)")
+        }
+        debug("ascArchivedFileURLs: \(ascArchivedFileURLs)")
+        return ascArchivedFileURLs
+    }
+
+    private func removeArchivedFiles(_ fileURL: URL, maxArchivedFilesCount: UInt8) {
+        do {
+            let archivedFileURLs = ascArchivedFileURLs(fileURL)
+            if archivedFileURLs.count > maxArchivedFilesCount {
+                for index in 0 ..< archivedFileURLs.count - Int(maxArchivedFilesCount) {
+                    debug("\(archivedFileURLs[index]) will be removed...")
+                    try FileManager.default.removeItem(at: archivedFileURLs[index])
+                    debug("\(archivedFileURLs[index]) has been removed")
+                    delegate?.fileRotationLogger(self, didRemoveArchivedFileURL: archivedFileURLs[index])
+                }
+            }
+        } catch {
+            print("error in removing extra archived files, error: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/Tests/PuppyTests/FileRotationLoggerTests.swift
+++ b/Tests/PuppyTests/FileRotationLoggerTests.swift
@@ -13,11 +13,33 @@ final class FileRotationLoggerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testFileRotationLogger() throws {
-        let rotationFileURL = URL(fileURLWithPath: "./rotation/rotation-foo.log").absoluteURL
-        let rotationDirectoryURL = URL(fileURLWithPath: "./rotation").absoluteURL
+    func testFileRotationNumbering() throws {
+        let rotationFileURL = URL(fileURLWithPath: "./rotation-numbering/rotation-numbering.log").absoluteURL
+        let rotationDirectoryURL = URL(fileURLWithPath: "./rotation-numbering").absoluteURL
 
-        let fileRotation = try FileRotationLogger("com.example.yourapp.filerotationlogger", fileURL: rotationFileURL)
+        let fileRotation = try FileRotationLogger("com.example.yourapp.filerotationlogger.numbering", fileURL: rotationFileURL)
+        // fileRotation.suffixExtension = .numbering    // default case
+        fileRotation.maxFileSize = 512
+        fileRotation.maxArchivedFilesCount = 4
+        fileRotation.delegate = self
+
+        let log = Puppy()
+        log.add(fileRotation)
+
+        for num in 0...3_000 {
+            log.info("\(num) numbering")
+        }
+
+        _ = fileRotation.delete(rotationDirectoryURL)
+        log.remove(fileRotation)
+    }
+
+    func testFileRotationDateUUID() throws {
+        let rotationFileURL = URL(fileURLWithPath: "./rotation-date_uuid/rotation-date_uuid.log").absoluteURL
+        let rotationDirectoryURL = URL(fileURLWithPath: "./rotation-date_uuid").absoluteURL
+
+        let fileRotation = try FileRotationLogger("com.example.yourapp.filerotationlogger.date_uuid", fileURL: rotationFileURL)
+        fileRotation.suffixExtension = .date_uuid
         fileRotation.maxFileSize = 256
         fileRotation.maxArchivedFilesCount = 2
         fileRotation.delegate = self
@@ -26,7 +48,7 @@ final class FileRotationLoggerTests: XCTestCase {
         log.add(fileRotation)
 
         for num in 0...1_000 {
-            log.info("\(num) message")
+            log.info("\(num) date_uuid")
         }
 
         _ = fileRotation.delete(rotationDirectoryURL)
@@ -36,10 +58,10 @@ final class FileRotationLoggerTests: XCTestCase {
 
 extension FileRotationLoggerTests: FileRotationLoggerDeletate {
     func fileRotationLogger(_ fileRotationLogger: FileRotationLogger, didArchiveFileURL: URL, toFileURL: URL) {
-        print("didArchive! didArchiveFileURL is \(didArchiveFileURL). toFileURL is \(toFileURL).")
+        print("didArchive! didArchiveFileURL: \(didArchiveFileURL), toFileURL: \(toFileURL)")
     }
 
     func fileRotationLogger(_ fileRotationLogger: FileRotationLogger, didRemoveArchivedFileURL: URL) {
-        print("didRemove! didRemoveArchivedFileURL is \(didRemoveArchivedFileURL).")
+        print("didRemove! didRemoveArchivedFileURL: \(didRemoveArchivedFileURL)")
     }
 }


### PR DESCRIPTION
This PR fixes #12 #27 .

`suffixExtension` was added to `FileRotationLogger`.

- .numbering (default option)
  - foo.log
  - foo.log1
  - foo.log2

- .date_uuid
  - foo.log
  - foo.log.20211118T1010Z_ecbaf8fe-3807-4056-b6a6-8a6c6b7b2c3e
  - foo.log.20211210T2238Z_7c64672e-8616-48d4-b780-66ca799d407b

Sample code is here.

```swift
let fileRotation = try! FileRotationLogger("com.example.yourapp.filerotation",
                                           fileURL: "./logs/foo.log")
fileRotation.suffixExtension = .date_uuid   // Default option is `.numbering`.
fileRotation.maxFileSize = 10 * 1024 * 1024
fileRotation.maxArchivedFilesCount = 2
fileRotation.delegate = delegate
let log = Puppy()
log.add(fileRotation)
log.info("INFO message")
log.warning("WARNING message")
```