### PR TITLE
Add option for file permission

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,10 @@ line_length:
   error: 240
   ignores_comments: true
 
+type_body_length:
+  - 400
+  - 500
+
 identifier_name:
   excluded:
     - at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `test_spec` in `podspec`. [#31](https://github.com/sushichop/Puppy/pull/31)
 - Add suffix extension types for `FileRotationLogger`. [#32](https://github.com/sushichop/Puppy/pull/32)
 - FileRotationLoggerDelegate Fix Spelling. [#34](https://github.com/sushichop/Puppy/pull/34)
+- Add option for file permission. [#36](https://github.com/sushichop/Puppy/pull/36)
 
 ## [0.3.1](https://github.com/sushichop/Puppy/releases/tag/0.3.1) (2021-08-18)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ import Puppy
 
 let console = ConsoleLogger("com.example.yourapp.console")
 let fileURL = URL(fileURLWithPath: "./foo.log").absoluteURL
-let file = FileLogger("com.example.yourapp.file", fileURL: fileURL)
+let file = FileLogger("com.example.yourapp.file",
+                      fileURL: fileURL,
+                      filePermission: "600")  // Default permission is "640". 
 
 let log = Puppy()
 // Set the logging level.

--- a/Sources/Puppy/FileError.swift
+++ b/Sources/Puppy/FileError.swift
@@ -1,10 +1,13 @@
 import Foundation
 
+public typealias Permission = String
+
 public enum FileError: Error, Equatable {
     case isNotFile(url: URL)
     case creatingDirectoryFailed(at: URL)
     case creatingFileFailed(at: URL)
     case writingFailed(at: URL)
+    case invalidPermssion(_ filePermission: Permission)
 }
 
 public enum FileDeletingError: Error, Equatable, LocalizedError {

--- a/Sources/Puppy/FileRotationLogger.swift
+++ b/Sources/Puppy/FileRotationLogger.swift
@@ -16,8 +16,8 @@ public class FileRotationLogger: FileLogger {
 
     public weak var delegate: FileRotationLoggerDelegate?
 
-    public init(_ label: String, fileURL: URL) throws {
-        try super.init(label, fileURL: fileURL)
+    public init(_ label: String, fileURL: URL, filePermssion: Permission = "640") throws {
+        try super.init(label, fileURL: fileURL, filePermisson: filePermssion)
     }
 
     public override func log(_ level: LogLevel, string: String) {

--- a/Tests/PuppyTests/FileLoggerTests.swift
+++ b/Tests/PuppyTests/FileLoggerTests.swift
@@ -253,4 +253,36 @@ final class FileLoggerTests: XCTestCase {
         log.remove(fileLogger)
     }
     #endif
+
+    func testFilePermssion() throws {
+        let fileURL = URL(fileURLWithPath: "./permisson600.log").absoluteURL
+        let fileLogger = try FileLogger("com.example.yourapp.filelogger.permisson600", fileURL: fileURL, filePermisson: "600")
+        let log = Puppy()
+        log.add(fileLogger)
+        log.trace("permisson, TRACE message using FileLogger")
+        log.verbose("permisson, VERBOSE message using FileLogger")
+        fileLogger.flush()
+
+        let attribute = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        // swiftlint:disable force_cast
+        let permission = attribute[FileAttributeKey.posixPermissions] as! Int16
+        // swiftlint:enable force_cast
+        let expectedPermission = Int16("600", radix: 8)!
+        XCTAssertEqual(permission, expectedPermission)
+
+        _ = fileLogger.delete(fileURL)
+        log.remove(fileLogger)
+    }
+
+    func testFilePermissionError() throws {
+        let permission800FileURL = URL(fileURLWithPath: "./permisson800.log").absoluteURL
+        XCTAssertThrowsError(try FileLogger("com.example.yourapp.filelogger.permisson800", fileURL: permission800FileURL, filePermisson: "800")) { error in
+            XCTAssertEqual(error as? FileError, .invalidPermssion("800"))
+        }
+
+        let permissionABCFileURL = URL(fileURLWithPath: "./permissonABC.log").absoluteURL
+        XCTAssertThrowsError(try FileLogger("com.example.yourapp.filelogger.permissonABC", fileURL: permissionABCFileURL, filePermisson: "ABC")) { error in
+            XCTAssertEqual(error as? FileError, .invalidPermssion("ABC"))
+        }
+    }
 }


### PR DESCRIPTION
This PR refers #35.

I have added an option for file permission.
You can use this feature as follows.
Default permission is "640"

```swift
// e.g. 1
FileLogger("com.example.yourapp.file",
                   fileURL: "./yourlog.log",
                   filePermission: "600")
// e.g. 2
try! FileRotationLogger("com.example.yourapp.filerotation",
                                        fileURL: "./logs/foo.log",
                                        filePermission: "660")
```
