### PR TITLE
Suppress `Run script build phase` warning about Swiftlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use macro for debugging. [#50](https://github.com/sushichop/Puppy/pull/50)
 - Move `Hashable` to `Loggerable`. [#51](https://github.com/sushichop/Puppy/pull/51)
 - Add a missing method. [#52](https://github.com/sushichop/Puppy/pull/52)
+- Suppress `Run script build phase` warning about Swiftlint. [#53](https://github.com/sushichop/Puppy/pull/53)
 
 ## [0.5.0](https://github.com/sushichop/Puppy/releases/tag/0.5.0) (2022-02-28)
 

--- a/Puppy.xcodeproj/project.pbxproj
+++ b/Puppy.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -489,6 +489,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		C78B9220252DCFEC0026B9B1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
Since swift files have been always linted so far, there are actually no changes.