### PR TITLE
Still use Xcode 13.4.1 for executing `pod lib lint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,23 @@ jobs:
       - uses: actions/checkout@v2
       - run: make ${{ matrix.make-target }}
 
+  cocoapods:
+    name: ${{ matrix.make-target }} - Xcode ${{ matrix.xcode }}
+    runs-on: macos-12
+    strategy:
+      matrix:
+        make-target:
+          [
+            pod-lib-lint,
+          ]
+        xcode: ['13.4.1']
+      fail-fast: false
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
+    steps:
+      - uses: actions/checkout@v2
+      - run: make ${{ matrix.make-target }}
+
   bazel:
     name: Bazel - Swift ${{ matrix.swift-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Disable bitcode. [#54](https://github.com/sushichop/Puppy/pull/54)
 - Update platform versions. [#55](https://github.com/sushichop/Puppy/pull/55)
 - Update to Xcode 14.0.1 and Swift 5.6 or later. [#56](https://github.com/sushichop/Puppy/pull/56)
+- Still use Xcode 13.4.1 for executing `pod lib lint`. [#57](https://github.com/sushichop/Puppy/pull/57)
 
 ## [0.5.1](https://github.com/sushichop/Puppy/releases/tag/0.5.1) (2022-09-24)
 

--- a/Puppy.podspec
+++ b/Puppy.podspec
@@ -13,12 +13,12 @@ Pod::Spec.new do |s|
 
   s.source            = { :git => "https://github.com/sushichop/Puppy.git", :tag => "#{s.version}" }
   
-  s.default_subspec   = "Core"
+  s.default_subspec   = "Default"
 
-  # s.subspec "Default" do |default|
-  #   default.dependency "Puppy/Core"
-  #   default.dependency "Logging", "~> 1.4"
-  # end
+  s.subspec "Default" do |default|
+    default.dependency "Puppy/Core"
+    default.dependency "Logging", "~> 1.4"
+  end
 
   s.subspec "Core" do |core|
     core.header_mappings_dir = "Sources/CPuppy/include"
@@ -26,9 +26,9 @@ Pod::Spec.new do |s|
     core.source_files        = "Sources/CPuppy/**/*.{h,c}", "Sources/Puppy/**/*.{swift}"
   end
 
-  # s.test_spec "UnitTests" do |unit_tests|
-  #   unit_tests.source_files  = "Tests/PuppyTests/**/*.{swift}"
-  # end
+  s.test_spec "UnitTests" do |unit_tests|
+    unit_tests.source_files  = "Tests/PuppyTests/**/*.{swift}"
+  end
 
   s.cocoapods_version = ">= 1.7.0"
   s.swift_versions    = ["5.0"]


### PR DESCRIPTION
See https://github.com/CocoaPods/CocoaPods/issues/11558.