### PR TITLE
Remove the dependency in podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove and change the properties. [#60](https://github.com/sushichop/Puppy/pull/60)
 - Change minimum platform versions. [#61](https://github.com/sushichop/Puppy/pull/61)
 - Adopt `Sendable` and `Loggerable`. [#62](https://github.com/sushichop/Puppy/pull/62)
+- Remove the dependency in podspec. [#66](https://github.com/sushichop/Puppy/pull/66)
 
 ## [0.5.1](https://github.com/sushichop/Puppy/releases/tag/0.5.1) (2022-09-24)
 

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "Puppy", targets: ["Puppy"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.4.4")),
     ],
     targets: [
         .target(name: "CPuppy",

--- a/Puppy.podspec
+++ b/Puppy.podspec
@@ -13,12 +13,7 @@ Pod::Spec.new do |s|
 
   s.source            = { :git => "https://github.com/sushichop/Puppy.git", :tag => "#{s.version}" }
   
-  s.default_subspec   = "Default"
-
-  s.subspec "Default" do |default|
-    default.dependency "Puppy/Core"
-    default.dependency "Logging", "~> 1.4"
-  end
+  s.default_subspec   = "Core"
 
   s.subspec "Core" do |core|
     core.header_mappings_dir = "Sources/CPuppy/include"


### PR DESCRIPTION
because `Logging` framework no longer supports CocoaPods. 
See https://github.com/apple/swift-log/pull/20.