### PR TITLE
Add another example of using `Puppy` with `Vapor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove the dependency in podspec. [#66](https://github.com/sushichop/Puppy/pull/66)
 - Update to `Xcode 14.1`. [#69](https://github.com/sushichop/Puppy/pull/69)
 - Use `#fileID` instead of `#file`. [#70](https://github.com/sushichop/Puppy/pull/70)
+- Add another example of using `Puppy` with [Vapor](https://vapor.codes). [#71](https://github.com/sushichop/Puppy/pull/71)
 
 ## [0.5.1](https://github.com/sushichop/Puppy/releases/tag/0.5.1) (2022-09-24)
 


### PR DESCRIPTION
See https://docs.vapor.codes/basics/logging/.
Related issue: https://github.com/sushichop/Puppy/issues/68