### PR TITLE
Add different error handling behaviors for disk writing errors

### DIFF
--- a/Sources/Puppy/FileLogger.swift
+++ b/Sources/Puppy/FileLogger.swift
@@ -11,8 +11,9 @@ public struct FileLogger: FileLoggerable {
     public let filePermission: String
 
     public let flushMode: FlushMode
+    public let writeMode: FileWritingErrorHandlingMode
 
-    public init(_ label: String, logLevel: LogLevel = .trace, logFormat: LogFormattable? = nil, fileURL: URL, filePermission: String = "640", flushMode: FlushMode = .always) throws {
+    public init(_ label: String, logLevel: LogLevel = .trace, logFormat: LogFormattable? = nil, fileURL: URL, filePermission: String = "640", flushMode: FlushMode = .always, writeMode: FileWritingErrorHandlingMode = .force) throws {
         self.label = label
         self.queue = DispatchQueue(label: label)
         self.logLevel = logLevel
@@ -23,6 +24,7 @@ public struct FileLogger: FileLoggerable {
         self.filePermission = filePermission
 
         self.flushMode = flushMode
+        self.writeMode = writeMode
 
         try validateFileURL(fileURL)
         try validateFilePermission(fileURL, filePermission: filePermission)
@@ -30,6 +32,6 @@ public struct FileLogger: FileLoggerable {
     }
 
     public func log(_ level: LogLevel, string: String) {
-        append(level, string: string, flushMode: flushMode)
+        append(level, string: string, flushMode: flushMode, writeMode: writeMode)
     }
 }


### PR DESCRIPTION
I was using Puppy during debugging a low disk space scenario. One crash was actually a side effect of logging with Puppy. The disk write failed due to low disk space. Using force trying to log is not always the right behavior for each logging use case.

<img width="1159" alt="Screenshot 2023-01-24 at 09 59 29" src="https://user-images.githubusercontent.com/1190948/214480022-e2efef70-d3c2-49f9-82c9-890e9f1a3e06.png">

For this scenario it's better to potentially lose some logs than to crash the app.

This PR adds two more error handling strategies for disk writes. There may be other valid error handling strategies.

- assert uses `assertionFailure` to stop execution for debug builds and ignores failures in release builds
- print only prints the error message to the standard output

The default option force has the current behavior. So this shouldn't be a breaking change, but allows Puppy users to pick a different behavior, when useful.