### PR TITLE
Workaround for `pod lib lint` on watchOS is no longer needed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           [
             xcode-test,
             xcode-build,
+            pod-lib-lint,
             carthage-build-workaround,
             carthage-build-xcframeworks,
           ]
@@ -97,21 +98,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make ${{ matrix.make-target }}
-
-  cocoapods:
-    name: CocoaPods - Xcode ${{ matrix.xcode }}
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        xcode: ['14.2']
-      fail-fast: false
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
-    steps:
-      - uses: actions/checkout@v3
-      # See https://github.com/CocoaPods/CocoaPods/issues/11558.
-      - run: |
-          pod lib lint --platforms=macos,ios,tvos --verbose --allow-warnings
 
   bazel:
     name: Bazel - Swift ${{ matrix.swift-version }} on ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [x.y.z](https://github.com/sushichop/Puppy/releases/tag/x.y.z) (yyyy-mm-dd)
+
+- Workaround for `pod lib lint` on watchOS is no longer needed. [#86](https://github.com/sushichop/Puppy/pull/86)
+
 ## [0.7.0](https://github.com/sushichop/Puppy/releases/tag/0.7.0) (2023-03-13)
 
 - Add different error handling behaviors for disk writing errors. [#75](https://github.com/sushichop/Puppy/pull/75)


### PR DESCRIPTION
See https://github.com/CocoaPods/CocoaPods/pull/11660. 
And now `macos-latest` image includes CocoaPods 1.12.0