### PR TITLE
fix: init date format otherwise no timestamp is present in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ class ViewController: UIViewController {
 struct LogFormatter: LogFormattable {
     private let dateFormat = DateFormatter()
 
+    init() {
+        dateFormat.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    }
+
     func formatMessage(_ level: LogLevel, message: String, tag: String, function: String,
                        file: String, line: UInt, swiftLogInfo: [String : String],
                        label: String, date: Date, threadID: UInt64) -> String {


### PR DESCRIPTION
Since https://github.com/sushichop/Puppy/pull/81, if dateFormat is not initialized, time stamp is not going to be logged.

Update the example to reflect this.