### PR TITLE
Add optional file protection + backup exclusion to FileLoggerable

### DIFF
--- a/Sources/Puppy/FileLogger.swift
+++ b/Sources/Puppy/FileLogger.swift
@@ -9,11 +9,20 @@ public struct FileLogger: FileLoggerable {
 
     public let fileURL: URL
     public let filePermission: String
+    public let fileProtectionType: FileProtectionType?
+    public let isExcludedFromBackup: Bool
 
     public let flushMode: FlushMode
     public let writeMode: FileWritingErrorHandlingMode
 
-    public init(_ label: String, logLevel: LogLevel = .trace, logFormat: LogFormattable? = nil, fileURL: URL, filePermission: String = "640", flushMode: FlushMode = .always, writeMode: FileWritingErrorHandlingMode = .force) throws {
+    public init(_ label: String,
+                logLevel: LogLevel = .trace,
+                logFormat: LogFormattable? = nil,
+                fileURL: URL, filePermission: String = "640",
+                fileProtectionType: FileProtectionType? = nil,
+                isExcludedFromBackup: Bool = false,
+                flushMode: FlushMode = .always,
+                writeMode: FileWritingErrorHandlingMode = .force) throws {
         self.label = label
         self.queue = DispatchQueue(label: label)
         self.logLevel = logLevel
@@ -22,6 +31,8 @@ public struct FileLogger: FileLoggerable {
         self.fileURL = fileURL
         puppyDebug("initialized, fileURL: \(fileURL)")
         self.filePermission = filePermission
+        self.fileProtectionType = fileProtectionType
+        self.isExcludedFromBackup = isExcludedFromBackup
 
         self.flushMode = flushMode
         self.writeMode = writeMode

--- a/Sources/Puppy/FileRotationLogger.swift
+++ b/Sources/Puppy/FileRotationLogger.swift
@@ -9,13 +9,23 @@ public struct FileRotationLogger: FileLoggerable {
 
     public let fileURL: URL
     public let filePermission: String
+    public var fileProtectionType: FileProtectionType?
+    public var isExcludedFromBackup: Bool
 
     let rotationConfig: RotationConfig
     private weak var delegate: FileRotationLoggerDelegate?
 
     private var dateFormat: DateFormatter
 
-    public init(_ label: String, logLevel: LogLevel = .trace, logFormat: LogFormattable? = nil, fileURL: URL, filePermission: String = "640", rotationConfig: RotationConfig, delegate: FileRotationLoggerDelegate? = nil) throws {
+    public init(_ label: String,
+                logLevel: LogLevel = .trace,
+                logFormat: LogFormattable? = nil,
+                fileURL: URL,
+                filePermission: String = "640",
+                fileProtectionType: FileProtectionType? = nil,
+                isExcludedFromBackup: Bool = false,
+                rotationConfig: RotationConfig,
+                delegate: FileRotationLoggerDelegate? = nil) throws {
         self.label = label
         self.queue = DispatchQueue(label: label)
         self.logLevel = logLevel
@@ -29,6 +39,8 @@ public struct FileRotationLogger: FileLoggerable {
         self.fileURL = fileURL
         puppyDebug("initialized, fileURL: \(fileURL)")
         self.filePermission = filePermission
+        self.fileProtectionType = fileProtectionType
+        self.isExcludedFromBackup = isExcludedFromBackup
 
         self.rotationConfig = rotationConfig
         self.delegate = delegate


### PR DESCRIPTION
This PR adds optional file protection and backup exclusion to FileLogger and FileRotationLogger. To my knowledge, these features are only available on Apple platforms, so the tests I've added will only run on those platforms. Maybe these features should be entirely gated behind compile-time checks? Open to feedback.