### PR TITLE
Bump swift version to 6.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "6d47708a9707c93086efc7397e28b7e841bb59e79b0895e008bd45f9298191b5",
   "pins" : [
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "Puppy", targets: ["Puppy"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.5.2")),
     ],
     targets: [
         .target(name: "CPuppy",
@@ -20,7 +20,8 @@ let package = Package(
         .target(name: "Puppy", dependencies: [.product(name: "Logging", package: "swift-log")],
                 exclude: ["CMakeLists.txt"]),
         .testTarget(name: "PuppyTests", dependencies: ["Puppy"]),
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )
 
 if let puppy = package.targets.first(where: { $0.name == "Puppy" }) {


### PR DESCRIPTION
Bump the swift version to 6.0 and Bump swift-log to 1.6.3.
This fixes an issue where swift-log would throw exceptions when running on Swift 6.0.

Related Issue: #97

Since I'm not very familiar with the CI part, could @sushichop please help take a look?